### PR TITLE
[codex] Harden dashboard security surfaces

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from "next/server"
 import { createSessionCookieValue, getAuthSettings, sessionCookieOptions, verifyPassword } from "@/app/lib/controlAuth"
+import { checkRateLimit, clearRateLimit, rateLimitKey, recordRateLimitFailure } from "@/app/lib/rateLimit"
+
+const AUTH_WINDOW_MS = 5 * 60 * 1000
+const AUTH_MAX_ATTEMPTS = 8
 
 export async function POST(request: NextRequest) {
   const settings = getAuthSettings()
@@ -13,11 +17,22 @@ export async function POST(request: NextRequest) {
   const body = await request.json().catch(() => ({}))
   const password = typeof body?.password === "string" ? body.password : ""
   const nextPath = typeof body?.next === "string" && body.next.startsWith("/") ? body.next : "/"
+  const limitKey = rateLimitKey(request, "auth:login")
+  const limit = checkRateLimit(limitKey, AUTH_MAX_ATTEMPTS, AUTH_WINDOW_MS)
+
+  if (limit.limited) {
+    return NextResponse.json(
+      { ok: false, error: "Too many login attempts. Try again shortly." },
+      { status: 429, headers: { "retry-after": String(limit.retryAfterSeconds) } },
+    )
+  }
 
   if (!await verifyPassword(password)) {
+    recordRateLimitFailure(limitKey, AUTH_WINDOW_MS)
     return NextResponse.json({ ok: false, error: "Invalid password" }, { status: 401 })
   }
 
+  clearRateLimit(limitKey)
   const response = NextResponse.json({ ok: true, next: nextPath })
   response.cookies.set(settings.cookieName, await createSessionCookieValue(), sessionCookieOptions)
   return response

--- a/app/api/auth/recover/route.ts
+++ b/app/api/auth/recover/route.ts
@@ -1,20 +1,35 @@
 import { NextRequest, NextResponse } from "next/server"
 import { createSessionCookieValue, getAuthSettings, sessionCookieOptions, verifyRecoveryToken } from "@/app/lib/controlAuth"
 import { updateLocalAuthCredentials } from "@/app/lib/controlAuthConfig"
+import { checkRateLimit, clearRateLimit, rateLimitKey, recordRateLimitFailure } from "@/app/lib/rateLimit"
+
+const RECOVERY_WINDOW_MS = 15 * 60 * 1000
+const RECOVERY_MAX_ATTEMPTS = 5
 
 export async function POST(request: NextRequest) {
   const body = await request.json().catch(() => ({}))
   const token = typeof body?.recoveryToken === "string" ? body.recoveryToken : ""
   const password = typeof body?.password === "string" ? body.password : ""
+  const limitKey = rateLimitKey(request, "auth:recover")
+  const limit = checkRateLimit(limitKey, RECOVERY_MAX_ATTEMPTS, RECOVERY_WINDOW_MS)
+
+  if (limit.limited) {
+    return NextResponse.json(
+      { ok: false, error: "Too many recovery attempts. Try again shortly." },
+      { status: 429, headers: { "retry-after": String(limit.retryAfterSeconds) } },
+    )
+  }
 
   if (password.length < 8) {
     return NextResponse.json({ ok: false, error: "Password must be at least 8 characters." }, { status: 400 })
   }
 
   if (!await verifyRecoveryToken(token)) {
+    recordRateLimitFailure(limitKey, RECOVERY_WINDOW_MS)
     return NextResponse.json({ ok: false, error: "Invalid recovery token." }, { status: 401 })
   }
 
+  clearRateLimit(limitKey)
   const result = await updateLocalAuthCredentials(password)
   const settings = getAuthSettings()
   const response = NextResponse.json({

--- a/app/api/auth/setup/route.ts
+++ b/app/api/auth/setup/route.ts
@@ -8,6 +8,10 @@ import {
   verifySessionCookieValue,
 } from "@/app/lib/controlAuth"
 import { updateLocalAuthCredentials } from "@/app/lib/controlAuthConfig"
+import { checkRateLimit, clearRateLimit, rateLimitKey, recordRateLimitFailure } from "@/app/lib/rateLimit"
+
+const SETUP_WINDOW_MS = 15 * 60 * 1000
+const SETUP_MAX_ATTEMPTS = 8
 
 function validPassword(password: string) {
   return password.length >= 8
@@ -19,6 +23,15 @@ export async function POST(request: NextRequest) {
   const password = typeof body?.password === "string" ? body.password : ""
   const currentPassword = typeof body?.currentPassword === "string" ? body.currentPassword : ""
   const recoveryToken = typeof body?.recoveryToken === "string" ? body.recoveryToken : ""
+  const limitKey = rateLimitKey(request, "auth:setup")
+  const limit = checkRateLimit(limitKey, SETUP_MAX_ATTEMPTS, SETUP_WINDOW_MS)
+
+  if (limit.limited) {
+    return NextResponse.json(
+      { ok: false, error: "Too many setup attempts. Try again shortly." },
+      { status: 429, headers: { "retry-after": String(limit.retryAfterSeconds) } },
+    )
+  }
 
   if (!validPassword(password)) {
     return NextResponse.json({ ok: false, error: "Password must be at least 8 characters." }, { status: 400 })
@@ -30,9 +43,11 @@ export async function POST(request: NextRequest) {
   const firstRun = !settings.configured
 
   if (!firstRun && !signedIn && !currentPasswordOk && !recoveryOk) {
+    recordRateLimitFailure(limitKey, SETUP_WINDOW_MS)
     return NextResponse.json({ ok: false, error: "Current password or recovery token required." }, { status: 401 })
   }
 
+  clearRateLimit(limitKey)
   const result = await updateLocalAuthCredentials(password)
   const response = NextResponse.json({
     ok: true,

--- a/app/api/sandbox/[sandboxId]/files/upload/route.ts
+++ b/app/api/sandbox/[sandboxId]/files/upload/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server"
-import { uploadSandboxFile } from "@/app/lib/sandboxFiles"
+import { assertRequestContentLength, uploadSandboxFile } from "@/app/lib/sandboxFiles"
 
 export async function POST(
   request: Request,
@@ -7,6 +7,7 @@ export async function POST(
 ) {
   try {
     const { sandboxId } = await params
+    assertRequestContentLength(request)
     const form = await request.formData()
     const file = form.get("file")
     const rawPath = form.get("path")

--- a/app/api/sandbox/[sandboxId]/restore/route.ts
+++ b/app/api/sandbox/[sandboxId]/restore/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server"
-import { restoreSandboxArchive } from "@/app/lib/sandboxFiles"
+import { assertRequestContentLength, restoreSandboxArchive } from "@/app/lib/sandboxFiles"
 import { recordActivity } from "@/app/lib/activityLog"
 
 export async function POST(
@@ -8,6 +8,7 @@ export async function POST(
 ) {
   try {
     const { sandboxId } = await params
+    assertRequestContentLength(request)
     const form = await request.formData()
     const file = form.get("archive")
     const rawTargetPath = form.get("targetPath")

--- a/app/lib/backupCatalog.ts
+++ b/app/lib/backupCatalog.ts
@@ -19,6 +19,12 @@ function sanitizeSegment(value: string) {
   return value.trim().replace(/[^\w.@:+-]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "") || "backup"
 }
 
+function normalizeBackupId(value: string) {
+  const safeId = sanitizeSegment(value)
+  if (safeId !== value) throw new Error("backup id contains unsupported characters")
+  return safeId
+}
+
 function archivePath(id: string) {
   return path.join(BACKUP_DIR, `${id}.tar.gz`)
 }
@@ -28,7 +34,7 @@ function metadataPath(id: string) {
 }
 
 async function ensureBackupDirectory() {
-  await mkdir(BACKUP_DIR, { recursive: true })
+  await mkdir(BACKUP_DIR, { recursive: true, mode: 0o700 })
 }
 
 export async function listBackupCatalog() {
@@ -67,8 +73,8 @@ export async function createCatalogBackup(sandboxId: string, sourcePath: string)
     createdAt: archive.createdAt,
   }
 
-  await writeFile(archivePath(id), archive.bytes)
-  await writeFile(metadataPath(id), `${JSON.stringify(entry, null, 2)}\n`)
+  await writeFile(archivePath(id), archive.bytes, { mode: 0o600 })
+  await writeFile(metadataPath(id), `${JSON.stringify(entry, null, 2)}\n`, { mode: 0o600 })
 
   const entries = await listBackupCatalog()
   await Promise.all(entries.slice(MAX_BACKUP_COUNT).map((stale) => deleteCatalogBackup(stale.id).catch(() => undefined)))
@@ -77,7 +83,7 @@ export async function createCatalogBackup(sandboxId: string, sourcePath: string)
 }
 
 export async function getCatalogBackup(id: string) {
-  const safeId = sanitizeSegment(id)
+  const safeId = normalizeBackupId(id)
   const metadata = JSON.parse(await readFile(metadataPath(safeId), "utf8")) as BackupCatalogEntry
   const bytes = await readFile(archivePath(safeId))
   return { metadata, bytes }
@@ -89,7 +95,7 @@ export async function restoreCatalogBackup(id: string, targetSandboxId: string, 
 }
 
 export async function deleteCatalogBackup(id: string) {
-  const safeId = sanitizeSegment(id)
+  const safeId = normalizeBackupId(id)
   await Promise.all([
     rm(archivePath(safeId), { force: true }),
     rm(metadataPath(safeId), { force: true }),

--- a/app/lib/rateLimit.ts
+++ b/app/lib/rateLimit.ts
@@ -1,0 +1,51 @@
+type RateLimitBucket = {
+  count: number
+  resetAt: number
+}
+
+const buckets = new Map<string, RateLimitBucket>()
+
+export type RateLimitResult = {
+  limited: boolean
+  retryAfterSeconds: number
+}
+
+function clientAddress(request: Request) {
+  const forwarded = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim()
+  return forwarded
+    || request.headers.get("x-real-ip")
+    || request.headers.get("cf-connecting-ip")
+    || "local"
+}
+
+export function rateLimitKey(request: Request, scope: string) {
+  return `${scope}:${clientAddress(request)}`
+}
+
+export function checkRateLimit(key: string, maxAttempts: number, windowMs: number): RateLimitResult {
+  const now = Date.now()
+  const current = buckets.get(key)
+  if (!current || current.resetAt <= now) {
+    return { limited: false, retryAfterSeconds: 0 }
+  }
+
+  return {
+    limited: current.count >= maxAttempts,
+    retryAfterSeconds: Math.max(1, Math.ceil((current.resetAt - now) / 1000)),
+  }
+}
+
+export function recordRateLimitFailure(key: string, windowMs: number) {
+  const now = Date.now()
+  const current = buckets.get(key)
+  const next = !current || current.resetAt <= now
+    ? { count: 1, resetAt: now + windowMs }
+    : { count: current.count + 1, resetAt: current.resetAt }
+
+  buckets.set(key, next)
+  return next
+}
+
+export function clearRateLimit(key: string) {
+  buckets.delete(key)
+}

--- a/app/lib/sandboxFiles.ts
+++ b/app/lib/sandboxFiles.ts
@@ -14,7 +14,8 @@ const HOST_PATH = [
   process.env.PATH || "",
 ].filter(Boolean).join(":")
 
-const MAX_FILE_BYTES = Number.parseInt(process.env.SANDBOX_FILE_TRANSFER_MAX_BYTES || String(128 * 1024 * 1024), 10)
+export const MAX_FILE_BYTES = Number.parseInt(process.env.SANDBOX_FILE_TRANSFER_MAX_BYTES || String(128 * 1024 * 1024), 10)
+export const MAX_MULTIPART_REQUEST_BYTES = MAX_FILE_BYTES + Math.min(10 * 1024 * 1024, Math.max(1024 * 1024, Math.floor(MAX_FILE_BYTES / 10)))
 const ALLOWED_ROOTS = ["/sandbox", "/tmp"]
 const MAX_LIST_ENTRIES = Number.parseInt(process.env.SANDBOX_FILE_LIST_MAX_ENTRIES || "200", 10)
 
@@ -44,6 +45,15 @@ export function normalizeSandboxPath(input: string, fallbackFileName?: string) {
   const allowed = ALLOWED_ROOTS.some((root) => normalized === root || normalized.startsWith(`${root}/`))
   if (!allowed) throw new Error("sandbox path must be under /sandbox or /tmp")
   return normalized
+}
+
+export function assertRequestContentLength(request: Request, maxBytes = MAX_MULTIPART_REQUEST_BYTES) {
+  const raw = request.headers.get("content-length")
+  if (!raw) return
+  const size = Number.parseInt(raw, 10)
+  if (Number.isFinite(size) && size > maxBytes) {
+    throw new Error(`request is too large; max transfer size is ${Math.floor(MAX_FILE_BYTES / 1024 / 1024)} MiB`)
+  }
 }
 
 function runSandboxExec(sandboxName: string, script: string, input?: Buffer, timeoutMs = 60000) {
@@ -224,14 +234,17 @@ export async function restoreSandboxArchive(
     `tmp_archive="$(mktemp /tmp/openshell-restore.XXXXXX.tar.gz)"`,
     `cat > "$tmp_archive"`,
     `tar -tzf "$tmp_archive" >/tmp/openshell-restore-list.$$`,
-    `while IFS= read -r entry; do case "$entry" in ""|/*|../*|*/../*|*"/..") rm -f "$tmp_archive" /tmp/openshell-restore-list.$$; exit 42;; esac; done < /tmp/openshell-restore-list.$$`,
+    `tar -tvzf "$tmp_archive" >/tmp/openshell-restore-verbose.$$`,
+    `while IFS= read -r entry; do case "$entry" in ""|/*|../*|*/../*|*"/..") rm -f "$tmp_archive" /tmp/openshell-restore-list.$$ /tmp/openshell-restore-verbose.$$; exit 42;; esac; done < /tmp/openshell-restore-list.$$`,
+    `while IFS= read -r entry; do case "$entry" in [-d]*) :;; *) rm -f "$tmp_archive" /tmp/openshell-restore-list.$$ /tmp/openshell-restore-verbose.$$; exit 43;; esac; done < /tmp/openshell-restore-verbose.$$`,
     `mkdir -p ${shellQuote(targetPath)}`,
     replace ? `find ${shellQuote(targetPath)} -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +` : `:`,
     `if grep -q '^payload/' /tmp/openshell-restore-list.$$; then tar -xzf "$tmp_archive" -C ${shellQuote(targetPath)} --strip-components=1 --wildcards 'payload/*'; else tar -xzf "$tmp_archive" -C ${shellQuote(targetPath)}; fi`,
-    `rm -f "$tmp_archive" /tmp/openshell-restore-list.$$`,
+    `rm -f "$tmp_archive" /tmp/openshell-restore-list.$$ /tmp/openshell-restore-verbose.$$`,
   ].join(" && ")
   const result = await runSandboxExec(sandboxName, script, payload, 120000)
   if (result.code === 42) throw new Error("archive contains unsafe paths")
+  if (result.code === 43) throw new Error("archive contains unsupported entry types")
   if (result.code !== 0) throw new Error(result.stderr || "failed to restore sandbox archive")
 
   return {

--- a/middleware.ts
+++ b/middleware.ts
@@ -22,35 +22,63 @@ function isAssetPath(pathname: string) {
   return pathname.startsWith("/_next/") || pathname.startsWith("/public/")
 }
 
+function withSecurityHeaders(response: NextResponse) {
+  response.headers.set("x-content-type-options", "nosniff")
+  response.headers.set("x-frame-options", "DENY")
+  response.headers.set("referrer-policy", "same-origin")
+  response.headers.set("permissions-policy", "camera=(), microphone=(), geolocation=()")
+  return response
+}
+
+function isStateChangingMethod(method: string) {
+  return !["GET", "HEAD", "OPTIONS"].includes(method.toUpperCase())
+}
+
+function hasTrustedOrigin(request: NextRequest) {
+  const origin = request.headers.get("origin")
+  if (!origin) return true
+
+  try {
+    return new URL(origin).origin === request.nextUrl.origin
+  } catch {
+    return false
+  }
+}
+
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
   const settings = getAuthSettings()
+
+  if (isStateChangingMethod(request.method) && !hasTrustedOrigin(request)) {
+    return withSecurityHeaders(NextResponse.json({ ok: false, error: "Untrusted request origin" }, { status: 403 }))
+  }
+
   if (settings.disabled || isAssetPath(pathname)) {
     if (pathname === "/login") {
-      return NextResponse.redirect(new URL("/", request.url))
+      return withSecurityHeaders(NextResponse.redirect(new URL("/", request.url)))
     }
-    return NextResponse.next()
+    return withSecurityHeaders(NextResponse.next())
   }
 
   if (isPublicPath(pathname)) {
     if (pathname === "/login" && await verifySessionCookieValue(request.cookies.get(settings.cookieName)?.value)) {
-      return NextResponse.redirect(new URL("/", request.url))
+      return withSecurityHeaders(NextResponse.redirect(new URL("/", request.url)))
     }
-    return NextResponse.next()
+    return withSecurityHeaders(NextResponse.next())
   }
 
   const authenticated = await verifySessionCookieValue(request.cookies.get(settings.cookieName)?.value)
   if (authenticated) {
-    return NextResponse.next()
+    return withSecurityHeaders(NextResponse.next())
   }
 
   if (pathname.startsWith("/api/")) {
-    return NextResponse.json({ ok: false, error: "Authentication required" }, { status: 401 })
+    return withSecurityHeaders(NextResponse.json({ ok: false, error: "Authentication required" }, { status: 401 }))
   }
 
   const loginUrl = new URL("/login", request.url)
   loginUrl.searchParams.set("next", `${pathname}${request.nextUrl.search}`)
-  return NextResponse.redirect(loginUrl)
+  return withSecurityHeaders(NextResponse.redirect(loginUrl))
 }
 
 export const config = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "nemo-shell-dashboard",
       "version": "0.1.0",
       "dependencies": {
-        "axios": "^1.7.7",
-        "next": "14.2.15",
+        "axios": "^1.15.2",
+        "next": "^14.2.35",
         "node-pty": "^1.1.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -25,8 +25,8 @@
         "@types/react-dom": "^18.3.1",
         "autoprefixer": "^10.4.20",
         "eslint": "^8.57.1",
-        "eslint-config-next": "14.2.15",
-        "postcss": "^8.4.49",
+        "eslint-config-next": "^14.2.35",
+        "postcss": "^8.5.10",
         "tailwindcss": "^3.4.15",
         "typescript": "^5.6.3"
       }
@@ -240,25 +240,57 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.15.tgz",
-      "integrity": "sha512-S1qaj25Wru2dUpcIZMjxeMVSwkt8BK4dmWHHiBuRstcIyOsMapqT4A4jSB6onvqeygkSSmOkyny9VVx8JIGamQ==",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
+      "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.15.tgz",
-      "integrity": "sha512-pKU0iqKRBlFB/ocOI1Ip2CkKePZpYpnw5bEItEkuZ/Nr9FQP1+p7VDWr4VfOdff4i9bFmrOaeaU1bFEyAcxiMQ==",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.35.tgz",
+      "integrity": "sha512-Jw9A3ICz2183qSsqwi7fgq4SBPiNfmOLmTPXKvlnzstUwyvBrtySiY+8RXJweNAs9KThb1+bYhZh9XWcNOr2zQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "glob": "10.3.10"
       }
     },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
+      "integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
+      "integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.15.tgz",
-      "integrity": "sha512-3Bwv4oc08ONiQ3FiOLKT72Q+ndEMyLNsc/D3qnLMbtUYTQAmkx9E/JRu0DBpHxNddBmNT5hxz1mYBphJ3mfrrw==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
+      "integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
       "cpu": [
         "arm64"
       ],
@@ -272,9 +304,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.15.tgz",
-      "integrity": "sha512-k5xf/tg1FBv/M4CMd8S+JL3uV9BnnRmoe7F+GWC3DxkTCD9aewFRH1s5rJ1zkzDa+Do4zyN8qD0N8c84Hu96FQ==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
+      "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
       "cpu": [
         "arm64"
       ],
@@ -282,6 +314,86 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
+      "integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
+      "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
+      "integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -1108,9 +1220,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -1951,13 +2063,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.2.15.tgz",
-      "integrity": "sha512-mKg+NC/8a4JKLZRIOBplxXNdStgxy7lzWuedUaCc8tev+Al9mwDUTujQH6W6qXDH9kycWiVo28tADWGvpBsZcQ==",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.2.35.tgz",
+      "integrity": "sha512-BpLsv01UisH193WyT/1lpHqq5iJ/Orfz9h/NOOlAmTUq4GY349PextQ62K4XpnaM9supeiEn3TaOTeQO07gURg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "14.2.15",
+        "@next/eslint-plugin-next": "14.2.35",
         "@rushstack/eslint-patch": "^1.3.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -2460,9 +2572,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -2705,9 +2817,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3816,13 +3928,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.15.tgz",
-      "integrity": "sha512-h9ctmOokpoDphRvMGnwOJAedT6zKhwqyZML9mDtspgf4Rh3Pn7UTYKqePNoDvhsWBAO5GoPNYshnAUGIazVGmw==",
-      "deprecated": "This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
+      "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "14.2.15",
+        "@next/env": "14.2.35",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -3837,15 +3948,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.15",
-        "@next/swc-darwin-x64": "14.2.15",
-        "@next/swc-linux-arm64-gnu": "14.2.15",
-        "@next/swc-linux-arm64-musl": "14.2.15",
-        "@next/swc-linux-x64-gnu": "14.2.15",
-        "@next/swc-linux-x64-musl": "14.2.15",
-        "@next/swc-win32-arm64-msvc": "14.2.15",
-        "@next/swc-win32-ia32-msvc": "14.2.15",
-        "@next/swc-win32-x64-msvc": "14.2.15"
+        "@next/swc-darwin-arm64": "14.2.33",
+        "@next/swc-darwin-x64": "14.2.33",
+        "@next/swc-linux-arm64-gnu": "14.2.33",
+        "@next/swc-linux-arm64-musl": "14.2.33",
+        "@next/swc-linux-x64-gnu": "14.2.33",
+        "@next/swc-linux-x64-musl": "14.2.33",
+        "@next/swc-win32-arm64-msvc": "14.2.33",
+        "@next/swc-win32-ia32-msvc": "14.2.33",
+        "@next/swc-win32-x64-msvc": "14.2.33"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -4284,9 +4395,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -6204,111 +6315,6 @@
         "react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.15.tgz",
-      "integrity": "sha512-Rvh7KU9hOUBnZ9TJ28n2Oa7dD9cvDBKua9IKx7cfQQ0GoYUwg9ig31O2oMwH3wm+pE3IkAQ67ZobPfEgurPZIA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.15.tgz",
-      "integrity": "sha512-5TGyjFcf8ampZP3e+FyCax5zFVHi+Oe7sZyaKOngsqyaNEpOgkKB3sqmymkZfowy3ufGA/tUgDPPxpQx931lHg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.15.tgz",
-      "integrity": "sha512-kE6q38hbrRbKEkkVn62reLXhThLRh6/TvgSP56GkFNhU22TbIrQDEMrO7j0IcQHcew2wfykq8lZyHFabz0oBrA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.15.tgz",
-      "integrity": "sha512-PZ5YE9ouy/IdO7QVJeIcyLn/Rc4ml9M2G4y3kCM9MNf1YKvFY4heg3pVa/jQbMro+tP6yc4G2o9LjAz1zxD7tQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.15.tgz",
-      "integrity": "sha512-2raR16703kBvYEQD9HNLyb0/394yfqzmIeyp2nDzcPV4yPjqNUG3ohX6jX00WryXz6s1FXpVhsCo3i+g4RUX+g==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.15.tgz",
-      "integrity": "sha512-fyTE8cklgkyR1p03kJa5zXEaZ9El+kDNM5A+66+8evQS5e/6v0Gk28LqA0Jet8gKSOyP+OTm/tJHzMlGdQerdQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.15.tgz",
-      "integrity": "sha512-SzqGbsLsP9OwKNUG9nekShTwhj6JSB9ZLMWQ8g1gG6hdE5gQLncbnbymrwy2yVmH9nikSLYRYxYMFu78Ggp7/g==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "terminal-server": "node terminal-server.mjs"
   },
   "dependencies": {
-    "axios": "^1.7.7",
-    "next": "14.2.15",
+    "axios": "^1.15.2",
+    "next": "14.2.35",
     "node-pty": "^1.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -28,8 +28,8 @@
     "@types/react-dom": "^18.3.1",
     "autoprefixer": "^10.4.20",
     "eslint": "^8.57.1",
-    "eslint-config-next": "14.2.15",
-    "postcss": "^8.4.49",
+    "eslint-config-next": "14.2.35",
+    "postcss": "^8.5.10",
     "tailwindcss": "^3.4.15",
     "typescript": "^5.6.3"
   }


### PR DESCRIPTION
## Summary
- Upgrade patchable dependencies including Next.js 14.2.35 and axios.
- Add rate limiting for login, recovery, and account setup attempts.
- Add baseline security headers and same-origin enforcement for state-changing requests.
- Harden file upload/restore request limits and tar restore entry validation.
- Tighten backup catalog ID validation and filesystem permissions.

## Security Notes
- `npm audit` no longer reports critical vulnerabilities after the patch upgrade.
- Remaining audit findings require a major Next.js upgrade to 16.x, so this PR keeps the framework on the current 14.x line and documents that residual risk.

## Validation
- `npm run build`
- `npm audit --audit-level=moderate --json`
- Secret-pattern scan with `rg`
- Manual checks for security headers on `/login` and foreign-origin POST rejection.