### PR TITLE
[codex] Trust forwarded dashboard origins

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -34,12 +34,49 @@ function isStateChangingMethod(method: string) {
   return !["GET", "HEAD", "OPTIONS"].includes(method.toUpperCase())
 }
 
+function firstForwardedValue(value: string | null) {
+  return value?.split(",")[0]?.trim() || null
+}
+
+function originFromHost(host: string | null, protocol: string) {
+  if (!host) return null
+  try {
+    const normalizedProtocol = protocol.endsWith(":") ? protocol : `${protocol}:`
+    return new URL(`${normalizedProtocol}//${host}`).origin
+  } catch {
+    return null
+  }
+}
+
+function publicBaseOrigin() {
+  if (!process.env.PUBLIC_BASE_URL) return null
+  try {
+    return new URL(process.env.PUBLIC_BASE_URL).origin
+  } catch {
+    return null
+  }
+}
+
+function trustedRequestOrigins(request: NextRequest) {
+  const forwardedProto = firstForwardedValue(request.headers.get("x-forwarded-proto"))
+  const forwardedHost = firstForwardedValue(request.headers.get("x-forwarded-host"))
+  const host = firstForwardedValue(request.headers.get("host"))
+  const protocol = forwardedProto || request.nextUrl.protocol || "http:"
+
+  return new Set([
+    request.nextUrl.origin,
+    originFromHost(host, protocol),
+    originFromHost(forwardedHost, protocol),
+    publicBaseOrigin(),
+  ].filter((origin): origin is string => Boolean(origin)))
+}
+
 function hasTrustedOrigin(request: NextRequest) {
   const origin = request.headers.get("origin")
   if (!origin) return true
 
   try {
-    return new URL(origin).origin === request.nextUrl.origin
+    return trustedRequestOrigins(request).has(new URL(origin).origin)
   } catch {
     return false
   }

--- a/tests/middleware-origin-forwarding-check.mjs
+++ b/tests/middleware-origin-forwarding-check.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+const root = process.cwd()
+const middlewarePath = path.join(root, 'middleware.ts')
+const middlewareSource = await readFile(middlewarePath, 'utf8')
+
+assert.match(
+  middlewareSource,
+  /function trustedRequestOrigins\(request: NextRequest\)/,
+  'middleware must collect trusted request origins for state-changing requests'
+)
+assert.match(
+  middlewareSource,
+  /request\.headers\.get\("x-forwarded-host"\)/,
+  'origin check must trust the forwarded public host behind a reverse proxy'
+)
+assert.match(
+  middlewareSource,
+  /request\.headers\.get\("x-forwarded-proto"\)/,
+  'origin check must preserve the forwarded public protocol behind a reverse proxy'
+)
+assert.match(
+  middlewareSource,
+  /process\.env\.PUBLIC_BASE_URL/,
+  'origin check should support an explicitly configured public base URL'
+)
+assert.match(
+  middlewareSource,
+  /trustedRequestOrigins\(request\)\.has\(new URL\(origin\)\.origin\)/,
+  'origin check must compare browser Origin against the trusted origin set'
+)
+assert.doesNotMatch(
+  middlewareSource,
+  /new URL\(origin\)\.origin === request\.nextUrl\.origin/,
+  'origin check must not only compare against the internal Next request origin'
+)
+
+console.log('middleware-origin-forwarding-check: PASS forwarded origin trust assertions')


### PR DESCRIPTION
## Summary

Fixes the live terminal initialization failure where state-changing API requests were rejected with `Untrusted request origin` behind a reverse proxy.

The middleware previously compared the browser `Origin` only to `request.nextUrl.origin`, which can be the internal Next.js server origin instead of the public dashboard URL. The updated check trusts the effective public request origins derived from `Host`, `X-Forwarded-Host`, `X-Forwarded-Proto`, and optional `PUBLIC_BASE_URL`, while still rejecting unrelated origins.

## Validation

- `node tests/middleware-origin-forwarding-check.mjs`
- `npm run lint`