### PR TITLE
chore: sync OpenShell/NemoClaw proxy bypass behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,8 @@ The controller also accepts an OpenShell config-file form at `~/.config/openshel
 
 Those values are translated into `OPENSHELL_GATEWAY_HOST`, `OPENSHELL_GATEWAY_PORT`, and `OPENSHELL_GATEWAY_URL` for controller-launched OpenShell/NemoClaw child processes.
 
+When the host shell has `HTTP_PROXY`/`HTTPS_PROXY` set, controller-launched OpenShell/NemoClaw commands also augment `NO_PROXY`/`no_proxy` for loopback, container-host aliases, and `inference.local`. This mirrors NemoClaw's current host-subprocess proxy bypass behavior and avoids routing local gateway or managed inference traffic through a workstation proxy.
+
 ## Security Limitations
 
 This is not production hardened.

--- a/app/lib/hostCommands.ts
+++ b/app/lib/hostCommands.ts
@@ -124,6 +124,39 @@ function stringConfigValue(value: unknown) {
   return undefined
 }
 
+function proxyBypassEnv() {
+  const hasProxy = Boolean(process.env.HTTP_PROXY || process.env.HTTPS_PROXY || process.env.http_proxy || process.env.https_proxy)
+  if (!hasProxy) return {}
+
+  const requiredBypasses = [
+    "localhost",
+    "127.0.0.1",
+    "host.docker.internal",
+    "host.containers.internal",
+    "::1",
+    "0.0.0.0",
+    "inference.local",
+  ]
+
+  const extend = (value: string | undefined) => {
+    const parts = (value || "")
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+
+    for (const host of requiredBypasses) {
+      if (!parts.includes(host)) parts.push(host)
+    }
+
+    return parts.join(",")
+  }
+
+  return {
+    NO_PROXY: extend(process.env.NO_PROXY),
+    no_proxy: extend(process.env.no_proxy),
+  }
+}
+
 function readOpenShellGatewayAddressConfig() {
   const configDir = OPENSHELL_XDG_CONFIG_HOME ? path.join(OPENSHELL_XDG_CONFIG_HOME, "openshell") : ""
   const candidates = unique([
@@ -173,6 +206,7 @@ export function hostCommandEnv(extra: Record<string, string | undefined> = {}) {
     ...(OPENSHELL_HOME ? { HOME: OPENSHELL_HOME } : {}),
     ...(OPENSHELL_XDG_CONFIG_HOME ? { XDG_CONFIG_HOME: OPENSHELL_XDG_CONFIG_HOME } : {}),
     ...openshellGatewayAddressEnv(),
+    ...proxyBypassEnv(),
     PATH: HOST_PATH,
     NO_COLOR: "1",
     CLICOLOR: "0",

--- a/tests/portable-install-check.mjs
+++ b/tests/portable-install-check.mjs
@@ -75,6 +75,9 @@ assert.match(versionedInstallSource, /NVIDIA_API_KEY="\$\{NVIDIA_API_KEY:-\}"/, 
 
 assert.match(hostCommandsSource, /export const HOST_PATH/, 'host command resolution must centralize PATH construction')
 assert.match(hostCommandsSource, /OPENSHELL_CONTROL_VENV/, 'host command resolution must include the installer-managed virtual environment')
+assert.match(hostCommandsSource, /function proxyBypassEnv\(\)/, 'host command env must augment NO_PROXY for controller-launched OpenShell/NemoClaw subprocesses')
+assert.match(hostCommandsSource, /"inference\.local"/, 'host command env must bypass host HTTP proxies for OpenShell-managed inference.local')
+assert.match(hostCommandsSource, /\.\.\.proxyBypassEnv\(\)/, 'host command env must apply proxy bypasses before launching host commands')
 assert.match(hostCommandsSource, /\.venv\/bin/, 'host command resolution must include the default project virtual environment')
 assert.match(hostCommandsSource, /\.nemoclaw\/source\/bin\/nemoclaw\.js/, 'host command resolution must support standard ~/.nemoclaw installs')
 assert.match(hostCommandsSource, /\.nemoclaw\/source\/scripts\/setup\.sh/, 'host command resolution must support legacy ~/.nemoclaw setup workflows')


### PR DESCRIPTION
## Summary
- Mirrors upstream NemoClaw's new host-subprocess proxy bypass behavior in controller-launched OpenShell/NemoClaw commands.
- Augments `NO_PROXY`/`no_proxy` for loopback hosts, container-host aliases, and `inference.local` whenever the controller host has `HTTP_PROXY`/`HTTPS_PROXY` set.
- Documents the runtime behavior and adds portability regression assertions.

## Upstream refs/versions
- NVIDIA/OpenShell: `b392b2eefec68d535ca53f21bbacadcdf47bcf67` (`feat(providersv2): add path auth_style (#1622)`)
- NVIDIA/NemoClaw: `d7aa5e0d827cc8bd90b881a9d016b4d4554073ad` (`fix(onboard): bypass host proxy for managed inference hostname (#4897)`)
- NemoClaw blueprint compatibility: `min_openshell_version: 0.0.44`, `max_openshell_version: 0.0.44`
- Controller base before branch: `c32aa0f1463a65101012e4f5d6004a3e7495dda6`

## Test Plan
- [x] `for t in tests/*.mjs; do node "$t"; done`
- [x] `npm run build`
- [x] `openshell --version`
- [x] `nemoclaw --version`
- [x] `openshell gateway list`
- [x] `openshell status`
- [x] `openshell sandbox list`
- [x] Controller API smoke with `OPENSHELL_CONTROL_AUTH_DISABLED=1 PORT=3217 npm run start`, then `curl -fsS http://127.0.0.1:3217/api/config/openshell` and `curl -fsS http://127.0.0.1:3217/api/telemetry/real`

## Fixes/Notes
- No sandboxes were created or destroyed; runtime smoke was read-only.
- Keeps OpenShell pinned to `v0.0.44` because current NemoClaw blueprint still pins that exact version.
