### PR TITLE
chore: sync NemoClaw inference credential env

### DIFF
--- a/app/api/sandbox/create/route.ts
+++ b/app/api/sandbox/create/route.ts
@@ -129,9 +129,10 @@ function applyCreateInferenceEnv(env: NodeJS.ProcessEnv, settings: CreateInferen
     settings.envSummary.push("NEMOCLAW_PROVIDER=nim-local")
     const apiKey = typeof body?.createInference?.apiKey === "string" ? body.createInference.apiKey.trim() : ""
     if (apiKey) {
+      env.NVIDIA_INFERENCE_API_KEY = apiKey
       env.NVIDIA_API_KEY = apiKey
       env.NEMOCLAW_PROVIDER_KEY = apiKey
-      settings.envSummary.push("NVIDIA_API_KEY=<provided>", "NEMOCLAW_PROVIDER_KEY=<provided>")
+      settings.envSummary.push("NVIDIA_INFERENCE_API_KEY=<provided>", "NVIDIA_API_KEY=<legacy-alias>", "NEMOCLAW_PROVIDER_KEY=<provided>")
     }
   }
 
@@ -790,7 +791,8 @@ export async function POST(request: Request) {
       })
 
       if (!enableTailscale) {
-        env.NVIDIA_API_KEY = env.NVIDIA_API_KEY || "optional-local-mode"
+        env.NVIDIA_INFERENCE_API_KEY = env.NVIDIA_INFERENCE_API_KEY || env.NVIDIA_API_KEY || "optional-local-mode"
+        env.NVIDIA_API_KEY = env.NVIDIA_API_KEY || env.NVIDIA_INFERENCE_API_KEY
       }
 
       applyCreateInferenceEnv(env, createInference, body)

--- a/app/components/ConfigurationPanel.tsx
+++ b/app/components/ConfigurationPanel.tsx
@@ -251,7 +251,7 @@ export default function ConfigurationPanel({ sandboxId, mode = 'existing', onCre
                 <input type="checkbox" checked={enableTailscale} onChange={(e) => setEnableTailscale(e.target.checked)} /> Enable Tailscale
               </label>
             )}
-            {enableTailscale && <div className="rounded-sm border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-300">Tailscale-enabled creation requires NVIDIA_API_KEY in the dashboard process environment.</div>}
+            {enableTailscale && <div className="rounded-sm border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-300">Tailscale-enabled creation requires NVIDIA_INFERENCE_API_KEY (or legacy NVIDIA_API_KEY) in the dashboard process environment.</div>}
             {isNemoClawOnboardBlueprint && <div className="rounded-sm border border-[var(--border-subtle)] bg-[var(--background)] p-4 space-y-4">
               <div>
                 <h6 className="text-xs font-semibold uppercase tracking-wider text-[var(--foreground)]">Inference at Create</h6>

--- a/install_versioned_nemoclaw_openshell.sh
+++ b/install_versioned_nemoclaw_openshell.sh
@@ -30,7 +30,7 @@ Usage:
   ./install_versioned_nemoclaw_openshell.sh [options]
 
 Options:
-  --nvidia-api-key KEY   Pass NVIDIA_API_KEY to the NemoClaw installer
+  --nvidia-api-key KEY   Pass NVIDIA_INFERENCE_API_KEY (and legacy NVIDIA_API_KEY) to the NemoClaw installer
   --skip-openshell       Do not install OpenShell
   --skip-nemoclaw        Do not install NemoClaw
   --help                 Show this help
@@ -60,7 +60,8 @@ Environment overrides:
   OPENSHELL_GATEWAY_HOST
   OPENSHELL_GATEWAY_PORT
   OPENSHELL_GATEWAY_URL
-  NVIDIA_API_KEY
+  NVIDIA_INFERENCE_API_KEY
+  NVIDIA_API_KEY (legacy alias)
 EOF
 }
 
@@ -68,7 +69,8 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --nvidia-api-key)
       [[ $# -ge 2 ]] || { echo -e "${RED}ERROR:${NC} --nvidia-api-key requires a value" >&2; exit 1; }
-      export NVIDIA_API_KEY="$2"
+      export NVIDIA_INFERENCE_API_KEY="$2"
+      export NVIDIA_API_KEY="${NVIDIA_API_KEY:-$2}"
       shift 2
       ;;
     --skip-openshell)
@@ -134,8 +136,14 @@ install_nemoclaw() {
   git -C "$source_dir" -c advice.detachedHead=false checkout --quiet --detach FETCH_HEAD
   [[ -n "$source_dir" && -f "$source_dir/install.sh" ]] || fail "Could not find NemoClaw install.sh in source checkout."
 
-  if [[ -z "${NVIDIA_API_KEY:-}" ]]; then
-    warn "NVIDIA_API_KEY is not set. NemoClaw may require it for non-local provider setup."
+  if [[ -z "${NVIDIA_INFERENCE_API_KEY:-}" && -n "${NVIDIA_API_KEY:-}" ]]; then
+    export NVIDIA_INFERENCE_API_KEY="$NVIDIA_API_KEY"
+  elif [[ -z "${NVIDIA_API_KEY:-}" && -n "${NVIDIA_INFERENCE_API_KEY:-}" ]]; then
+    export NVIDIA_API_KEY="$NVIDIA_INFERENCE_API_KEY"
+  fi
+
+  if [[ -z "${NVIDIA_INFERENCE_API_KEY:-}" ]]; then
+    warn "NVIDIA_INFERENCE_API_KEY is not set. NemoClaw may require it for non-local provider setup."
   fi
 
   log "Installing NemoClaw $NEMOCLAW_INSTALL_REF"
@@ -147,6 +155,7 @@ install_nemoclaw() {
       NEMOCLAW_NON_INTERACTIVE="$NEMOCLAW_NON_INTERACTIVE" \
       NEMOCLAW_EXPERIMENTAL="$NEMOCLAW_EXPERIMENTAL" \
       NEMOCLAW_PROVIDER="$NEMOCLAW_PROVIDER" \
+      NVIDIA_INFERENCE_API_KEY="${NVIDIA_INFERENCE_API_KEY:-}" \
       NVIDIA_API_KEY="${NVIDIA_API_KEY:-}" \
       ./install.sh
   )

--- a/tests/portable-install-check.mjs
+++ b/tests/portable-install-check.mjs
@@ -71,7 +71,11 @@ assert.match(versionedInstallSource, /NEMOCLAW_EXPERIMENTAL="\$\{NEMOCLAW_EXPERI
 assert.match(versionedInstallSource, /NEMOCLAW_PROVIDER="\$\{NEMOCLAW_PROVIDER:-vllm\}"/, 'versioned installer must default NemoClaw to the vLLM provider')
 assert.match(versionedInstallSource, /NEMOCLAW_EXPERIMENTAL="\$NEMOCLAW_EXPERIMENTAL"/, 'versioned installer must pass experimental mode through to NemoClaw install')
 assert.match(versionedInstallSource, /NEMOCLAW_PROVIDER="\$NEMOCLAW_PROVIDER"/, 'versioned installer must pass the provider through to NemoClaw install')
-assert.match(versionedInstallSource, /NVIDIA_API_KEY="\$\{NVIDIA_API_KEY:-\}"/, 'versioned installer must pass NVIDIA_API_KEY through to NemoClaw install')
+assert.match(versionedInstallSource, /NVIDIA_INFERENCE_API_KEY="\$\{NVIDIA_INFERENCE_API_KEY:-\}"/, 'versioned installer must pass NVIDIA_INFERENCE_API_KEY through to NemoClaw install')
+assert.match(versionedInstallSource, /NVIDIA_API_KEY="\$\{NVIDIA_API_KEY:-\}"/, 'versioned installer must continue passing legacy NVIDIA_API_KEY through to NemoClaw install')
+assert.match(createRouteSource, /env\.NVIDIA_INFERENCE_API_KEY = apiKey/, 'create-time inference must export NemoClaw current NVIDIA inference credential env')
+assert.match(createRouteSource, /env\.NVIDIA_API_KEY = apiKey/, 'create-time inference must retain the legacy NVIDIA_API_KEY alias for older NemoClaw builds')
+assert.match(createRouteSource, /NVIDIA_INFERENCE_API_KEY=<provided>/, 'create-time inference summaries must mention the current credential env without printing secrets')
 
 assert.match(hostCommandsSource, /export const HOST_PATH/, 'host command resolution must centralize PATH construction')
 assert.match(hostCommandsSource, /OPENSHELL_CONTROL_VENV/, 'host command resolution must include the installer-managed virtual environment')


### PR DESCRIPTION
## Summary
- Sync the controller with current NemoClaw `main` credential environment drift from `NVIDIA_API_KEY` toward `NVIDIA_INFERENCE_API_KEY`.
- Keep the legacy `NVIDIA_API_KEY` alias populated for older NemoClaw/OpenClaw paths.
- Update the create-time inference UI/API summaries and regression assertions so credential values remain redacted.

## Upstream refs/versions
- Controller base: `32423c8d0a851d5f7cd0ebdf7fc870f6eca243dc`
- OpenShell main: `21ff5db950ad99e472692637f0cfba002baa9202` (`ci(stale): add stale issue and PR workflow (#1890)`); latest tag observed `v0.0.62`
- NemoClaw main: `626a7ce217571e12fb5722d014b95c387061f513` (`fix(wechat): avoid logging QR poll tokens (#5179)`); latest tag observed `v0.0.64`
- NemoClaw blueprint still pins `min_openshell_version: "0.0.44"` and `max_openshell_version: "0.0.44"`
- NemoClaw `Dockerfile.base` still defaults `OPENCLAW_VERSION=2026.5.27`

## Test Plan
- `npm ci`
- `for t in tests/*.mjs; do node "$t"; done`
- `npm run build`
- `openshell --version`
- `openshell gateway list`
- `openshell status`
- `openshell sandbox list`
- Controller API smoke: `PORT=3158 NEXT_PUBLIC_DASHBOARD_PORT=3158 OPENSHELL_CONTROL_AUTH_DISABLED=1 npm start`, then `GET /api/config/openshell` and `GET /api/telemetry/real`

## Fixes/Notes
- Local `nemoclaw --version` still fails because the local shim points at missing `/opt/homebrew/bin/nemoclaw`; this is pre-existing local CLI shim drift and did not block OpenShell/controller read-only smokes.
- No user sandboxes were created or destroyed.
