### PR TITLE
docs: fix OpenShell compatibility helper default

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Install or refresh the locked OpenShell/NemoClaw pair first:
 ./install_versioned_nemoclaw_openshell.sh
 ```
 
-That helper defaults to `OPENSHELL_VERSION=v0.0.71`, `NEMOCLAW_INSTALL_REF=main`, and `OPENCLAW_VERSION=2026.5.27`.
+That helper defaults to `OPENSHELL_VERSION=v0.0.72`, `NEMOCLAW_INSTALL_REF=main`, and `OPENCLAW_VERSION=2026.5.27`.
 
 Then install the dashboard from the repository root:
 


### PR DESCRIPTION
## Summary
- Fix a stale README install section that still claimed the versioned helper defaulted to OpenShell `v0.0.71`.
- Keep docs aligned with the current NemoClaw blueprint pin and installer/test defaults for OpenShell `v0.0.72`.

## Upstream refs/versions
- Controller base `origin/main`: `d48e04a75e1611147491d54831eff45d269fc3a4`.
- NVIDIA/OpenShell `main`: `f852d07b6bef573f377a119a3c007848cdf8cadb` (`docs: add Hermes Agent to supported agents table (#2131)`).
- NVIDIA/NemoClaw `main`: `7875bd3c24ecba22a144f46617842fffd4600878` (`fix(onboard): harden BuildKit prebuild validation (#6265)`).
- NemoClaw blueprint: `min_openshell_version: "0.0.72"`, `max_openshell_version: "0.0.72"`.
- NemoClaw `Dockerfile.base` still defaults `OPENCLAW_VERSION=2026.5.27`.

## Test Plan
- `npm install`
- `for t in tests/*.mjs; do node "$t"; done`
- `npm run build`
- `git diff --check`
- Added-line secret scan with local Python regex check
- Runtime smokes:
  - `openshell --version` -> `openshell 0.0.44` on this host
  - `nemoclaw --version` -> blocked by stale local shim at `/Users/markmckeen/.local/bin/nemoclaw` pointing to missing `/opt/homebrew/bin/nemoclaw`
  - `openshell gateway list` -> passed; active gateway is `nemoclaw` at `http://127.0.0.1:8080`
  - `openshell status` and `openshell sandbox list` -> failed because active `nemoclaw` gateway port refused connection
  - Controller API smoke on `127.0.0.1:43125` with auth disabled: `/api/config/openshell` passed; `/api/telemetry/real` returned 500 due unreachable active gateway; `/api/sandbox/create` validation returned 400 without creating a sandbox

## Fixes/Notes
- No secrets are included in this PR body or commit.
- This PR intentionally does not run installers or recreate/destroy sandboxes from the cron job.
