### PR TITLE
chore: license project under MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mark Mckeen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -466,4 +466,4 @@ npm run dev
 
 ## License
 
-Internal development prototype. Add the appropriate license before distribution.
+OpenShell Control is available under the [MIT License](LICENSE). You may use, copy, modify, merge, publish, distribute, sublicense, and sell copies, provided the copyright and permission notices are retained. The software is provided without warranty.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "nemo-shell-dashboard",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "axios": "^1.15.2",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "nemo-shell-dashboard",
   "version": "0.1.0",
   "private": true,
+  "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development node server.mjs",
     "dev:proxy": "NODE_ENV=development node server.mjs",


### PR DESCRIPTION
## Summary
- add the canonical MIT License with 2026 Mark Mckeen copyright
- declare `MIT` in `package.json` and root `package-lock.json` metadata
- replace the README placeholder with an MIT license summary and link

## Validation
- npm package/lock license metadata assertions
- canonical MIT text assertions
- stale project-license wording scan
- `git diff --check`
- added-line credential scan